### PR TITLE
Remove unused firebase/firestore import

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,7 @@ jobs:
         uses: codecov/codecov-action@v1.0.6
         with:
           file: coverage/clover.xml
+          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1.0.0

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,6 @@ jobs:
         uses: codecov/codecov-action@v1.0.6
         with:
           file: coverage/clover.xml
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
 
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1.0.0

--- a/features/exercise/ExerciseListScreen.tsx
+++ b/features/exercise/ExerciseListScreen.tsx
@@ -1,4 +1,3 @@
-import "firebase/firestore";
 import React, { FC } from "react";
 import { FlatList, FlatListProps, StyleSheet, Text, View } from "react-native";
 


### PR DESCRIPTION
### 👊 What

- Removes an unused, unnecessary `import "firebase/firestore";`

### 🤔 Why

- When I was struggling to get the Expo babel cache to refresh, this import red screened the app on me
- I think we only want one of these `import "firebase/firestore"` statements, early on in our app lifecycle, because the import is for side-effects (where it patches the core firebase module to have `firestore()` functionality)

### ✉️ P.S.

- I didn't create an issue first for this one, because it's a `-1/+0` change