### PR TITLE
Configure the stale bot in Github Workflows

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,2 @@
+daysUntilStale: 7
+staleLabel: stale


### PR DESCRIPTION
### 👊 What

- Integrates the stale bot, like at work

### 🤔 Why

- Automates keeping our issues and PRs clean, after 7 days of inactivity they get the "stale" label, and then 7 days later they're closed

### 📓 Documentation

- https://probot.github.io/apps/stale/