### PR TITLE
Use Jest's --ci flag in Github Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,7 +44,7 @@ jobs:
         run: yarn lint
 
       - name: Test
-        run: yarn test --coverage
+        run: yarn test --ci --coverage
 
       - name: Codecov
         uses: codecov/codecov-action@v1.0.6


### PR DESCRIPTION
### 👊 What

- Uses Jest's `--ci` flag in our CI

### 🤔 Why

- We might as well use the CI options for our tools we're using in CI 😆

### 📓 Documentation

- [Jest](https://jestjs.io/docs/en/cli.html#--ci)
