### PR TITLE
Remove codecov action in Github Workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,12 +46,6 @@ jobs:
       - name: Test
         run: yarn test --coverage
 
-      - name: Codecov
-        uses: codecov/codecov-action@v1.0.6
-        with:
-          file: coverage/clover.xml
-          token: ${{ secrets.CODECOV_TOKEN }} # not required for public repos
-
       - name: Archive code coverage results
         uses: actions/upload-artifact@v1.0.0
         with:


### PR DESCRIPTION
### 👊 What

- Removes the codecov Github Action in our Github Workflow

### 🤔 Why

- They're having downtime issues right now
- We already have code coverage results for every CI run in the artifacts
- This adds a decent chunk of time onto each CI run