### PR TITLE
(1) Create empty and error views, alongside the loading view

### DIFF
--- a/features/exercise/ExerciseListScreen.tsx
+++ b/features/exercise/ExerciseListScreen.tsx
@@ -11,7 +11,9 @@ import {
 } from "react-native";
 import { captureException } from "sentry-expo";
 
-import { Loading } from "../ui/Loading";
+import { EmptyView } from "../ui/EmptyView";
+import { ErrorView } from "../ui/ErrorView";
+import { LoadingView } from "../ui/LoadingView";
 import { Exercise, useExercises } from "./useExercises";
 
 type Props = { navigation: StackNavigationProp<ParamListBase> };
@@ -30,10 +32,14 @@ export const ExerciseListScreen: FC<Props> = function ({ navigation }) {
     ),
   });
 
-  const [exercises, loading] = useExercises();
+  const { error, exercises, loading } = useExercises();
 
   return loading ? (
-    <Loading />
+    <LoadingView />
+  ) : error ? (
+    <ErrorView />
+  ) : !exercises?.length ? (
+    <EmptyView />
   ) : (
     <View style={styles.container}>
       <FlatList

--- a/features/exercise/useExercises.ts
+++ b/features/exercise/useExercises.ts
@@ -8,8 +8,9 @@ export interface Exercise {
 }
 
 export function useExercises() {
-  const [exercises, setExercises] = useState<readonly Exercise[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Readonly<Error> | null>();
+  const [exercises, setExercises] = useState<readonly Exercise[] | null>();
+  const [loading, setLoading] = useState<Readonly<boolean>>(true);
 
   useEffect(function () {
     async function fetchExercises() {
@@ -23,9 +24,13 @@ export function useExercises() {
           name: snapshot.data().name,
         }));
 
+        setError(null);
         setExercises(exercises);
       } catch (error) {
         captureException(error);
+
+        setError(error);
+        setExercises(null);
       } finally {
         setLoading(false);
       }
@@ -34,5 +39,5 @@ export function useExercises() {
     fetchExercises();
   }, []);
 
-  return [exercises, loading] as const;
+  return { error, exercises, loading };
 }

--- a/features/habit/HabitListScreen.tsx
+++ b/features/habit/HabitListScreen.tsx
@@ -1,14 +1,20 @@
 import React, { FC } from "react";
 import { FlatList, FlatListProps, StyleSheet, Text, View } from "react-native";
 
-import { Loading } from "../ui/Loading";
+import { EmptyView } from "../ui/EmptyView";
+import { ErrorView } from "../ui/ErrorView";
+import { LoadingView } from "../ui/LoadingView";
 import { Habit, useHabits } from "./useHabits";
 
 export const HabitListScreen: FC = function () {
-  const [habits, loading] = useHabits();
+  const { error, habits, loading } = useHabits();
 
   return loading ? (
-    <Loading />
+    <LoadingView />
+  ) : error ? (
+    <ErrorView />
+  ) : !habits?.length ? (
+    <EmptyView />
   ) : (
     <View style={styles.container}>
       <FlatList

--- a/features/habit/useHabits.ts
+++ b/features/habit/useHabits.ts
@@ -8,8 +8,9 @@ export interface Habit {
 }
 
 export function useHabits() {
-  const [habits, setHabits] = useState<readonly Habit[]>([]);
-  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<Readonly<Error> | null>();
+  const [habits, setHabits] = useState<readonly Habit[] | null>();
+  const [loading, setLoading] = useState<Readonly<boolean>>(true);
 
   useEffect(function () {
     async function fetchHabits() {
@@ -20,9 +21,13 @@ export function useHabits() {
           name: snapshot.data().name,
         }));
 
+        setError(null);
         setHabits(habits);
       } catch (error) {
         captureException(error);
+
+        setError(error);
+        setHabits(null);
       } finally {
         setLoading(false);
       }
@@ -31,5 +36,5 @@ export function useHabits() {
     fetchHabits();
   }, []);
 
-  return [habits, loading] as const;
+  return { error, habits, loading };
 }

--- a/features/ui/EmptyView.tsx
+++ b/features/ui/EmptyView.tsx
@@ -1,0 +1,22 @@
+import React, { FC } from "react";
+import { StyleSheet, Text, View } from "react-native";
+
+export const EmptyView: FC = function () {
+  return (
+    <View style={styles.container}>
+      <Text style={styles.text}>🤷‍♀️</Text>
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    backgroundColor: "#fff",
+    flex: 1,
+    justifyContent: "center",
+  },
+  text: {
+    fontSize: 72,
+  },
+});

--- a/features/ui/ErrorView.tsx
+++ b/features/ui/ErrorView.tsx
@@ -1,10 +1,10 @@
 import React, { FC } from "react";
-import { ActivityIndicator, StyleSheet, View } from "react-native";
+import { StyleSheet, Text, View } from "react-native";
 
-export const Loading: FC = function () {
+export const ErrorView: FC = function () {
   return (
     <View style={styles.container}>
-      <ActivityIndicator />
+      <Text style={styles.text}>💩</Text>
     </View>
   );
 };
@@ -15,5 +15,8 @@ const styles = StyleSheet.create({
     backgroundColor: "#fff",
     flex: 1,
     justifyContent: "center",
+  },
+  text: {
+    fontSize: 72,
   },
 });

--- a/features/ui/LoadingView.tsx
+++ b/features/ui/LoadingView.tsx
@@ -1,0 +1,19 @@
+import React, { FC } from "react";
+import { ActivityIndicator, StyleSheet, View } from "react-native";
+
+export const LoadingView: FC = function () {
+  return (
+    <View style={styles.container}>
+      <ActivityIndicator />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    alignItems: "center",
+    backgroundColor: "#fff",
+    flex: 1,
+    justifyContent: "center",
+  },
+});

--- a/features/ui/__tests__/EmptyView.test.tsx
+++ b/features/ui/__tests__/EmptyView.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import { EmptyView } from "../EmptyView";
+
+describe("<EmptyView />", () => {
+  it("renders correctly", () => {
+    const tree = renderer.create(<EmptyView />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/features/ui/__tests__/ErrorView.test.tsx
+++ b/features/ui/__tests__/ErrorView.test.tsx
@@ -1,11 +1,11 @@
 import React from "react";
 import renderer from "react-test-renderer";
 
-import { Loading } from "../Loading";
+import { ErrorView } from "../ErrorView";
 
-describe("<Loading />", () => {
+describe("<ErrorView />", () => {
   it("renders correctly", () => {
-    const tree = renderer.create(<Loading />).toJSON();
+    const tree = renderer.create(<ErrorView />).toJSON();
 
     expect(tree).toMatchSnapshot();
   });

--- a/features/ui/__tests__/LoadingView.test.tsx
+++ b/features/ui/__tests__/LoadingView.test.tsx
@@ -1,0 +1,12 @@
+import React from "react";
+import renderer from "react-test-renderer";
+
+import { LoadingView } from "../LoadingView";
+
+describe("<LoadingView />", () => {
+  it("renders correctly", () => {
+    const tree = renderer.create(<LoadingView />).toJSON();
+
+    expect(tree).toMatchSnapshot();
+  });
+});

--- a/features/ui/__tests__/__snapshots__/EmptyView.test.tsx.snap
+++ b/features/ui/__tests__/__snapshots__/EmptyView.test.tsx.snap
@@ -1,0 +1,24 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<EmptyView /> renders correctly 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#fff",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <Text
+    style={
+      Object {
+        "fontSize": 72,
+      }
+    }
+  >
+    🤷‍♀️
+  </Text>
+</View>
+`;

--- a/features/ui/__tests__/__snapshots__/ErrorView.test.tsx.snap
+++ b/features/ui/__tests__/__snapshots__/ErrorView.test.tsx.snap
@@ -1,6 +1,6 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`<Loading /> renders correctly 1`] = `
+exports[`<ErrorView /> renders correctly 1`] = `
 <View
   style={
     Object {
@@ -11,11 +11,14 @@ exports[`<Loading /> renders correctly 1`] = `
     }
   }
 >
-  <ActivityIndicator
-    animating={true}
-    color="#999999"
-    hidesWhenStopped={true}
-    size="small"
-  />
+  <Text
+    style={
+      Object {
+        "fontSize": 72,
+      }
+    }
+  >
+    💩
+  </Text>
 </View>
 `;

--- a/features/ui/__tests__/__snapshots__/LoadingView.test.tsx.snap
+++ b/features/ui/__tests__/__snapshots__/LoadingView.test.tsx.snap
@@ -1,0 +1,21 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`<LoadingView /> renders correctly 1`] = `
+<View
+  style={
+    Object {
+      "alignItems": "center",
+      "backgroundColor": "#fff",
+      "flex": 1,
+      "justifyContent": "center",
+    }
+  }
+>
+  <ActivityIndicator
+    animating={true}
+    color="#999999"
+    hidesWhenStopped={true}
+    size="small"
+  />
+</View>
+`;


### PR DESCRIPTION
## ⚠️ This pull request blocks #62

### 👊 What

- Creates an empty and error view, alongside the loading view

### 🤔 Why

- It's handy to have these shared components for both lists; nuthin' fancy, but it'll do for now

Closes #58 