### PR TITLE
lock npm packages versionings

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+save-exact=true


### PR DESCRIPTION
Lock down dependency versions in the `.npmrc` file.

The app should work as normal with no breaking changes.

https://medium.com/the-guild/how-should-you-pin-your-npm-dependencies-and-why-2b8d545c7312