### PR TITLE
Enable screens

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -9,11 +9,13 @@ import { StatusBar } from "react-native";
 import { AppearanceProvider, useColorScheme } from "react-native-appearance";
 
 import { configureFirebase } from "./config/configureFirebase";
+import { configureScreens } from "./config/configureScreens";
 import { configureSentry } from "./config/configureSentry";
 import { client } from "./data/client";
 import { ModalStackScreen } from "./features/ui/ModalStackScreen";
 
 configureFirebase();
+configureScreens();
 configureSentry();
 
 export default function App() {

--- a/config/__tests__/configureScreens.test.ts
+++ b/config/__tests__/configureScreens.test.ts
@@ -1,0 +1,17 @@
+import * as screens from "react-native-screens";
+
+import { configureScreens } from "../configureScreens";
+
+jest.mock("react-native-screens");
+
+describe("configureScreens()", () => {
+  it("should enable screens", () => {
+    const spy = jest
+      .spyOn(screens, "enableScreens")
+      .mockImplementationOnce(() => {});
+
+    configureScreens();
+
+    expect(spy).toHaveBeenCalledTimes(1);
+  });
+});

--- a/config/configureScreens.ts
+++ b/config/configureScreens.ts
@@ -1,0 +1,5 @@
+import { enableScreens } from "react-native-screens";
+
+export const configureScreens = function () {
+  enableScreens();
+};


### PR DESCRIPTION
Enabling `react-native-screens` is a performance optimization that gets react-navigation to use native screens (containers) instead of `<View />` components